### PR TITLE
add experimental folder to tests for exp_recursive_shared_mutex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LINK:=$(CXX)
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
-DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/rsm $(CURDIR)/rsm/experimental $(CURDIR)/rsm/test $(BOOST_INCLUDE_PATH))
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/rsm $(CURDIR)/rsm/experimental $(CURDIR)/rsm/test $(CURDIR)/rsm/test/experimental $(BOOST_INCLUDE_PATH))
 LIBS = $(addprefix -L,$(BOOST_LIB_PATH))
 
 LIBS += \
@@ -22,6 +22,9 @@ BUILD= \
     build/rsm/test/rsm_promotion_tests.o \
     build/rsm/test/rsm_simple_tests.o \
     build/rsm/test/rsm_starvation_tests.o \
+	build/rsm/test/experimental/exp_rsm_promotion_tests.o \
+    build/rsm/test/experimental/exp_rsm_simple_tests.o \
+    build/rsm/test/experimental/exp_rsm_starvation_tests.o \
     build/rsm/test/test_cxx_rsm.o \
     build/rsm/test/timer.o
 
@@ -41,6 +44,9 @@ directories:
 	fi; \
 	if [ ! -d "$(CURDIR)/build/rsm/test" ]; then \
 		mkdir $(CURDIR)/build/rsm/test; \
+	fi;
+	if [ ! -d "$(CURDIR)/build/rsm/test/experimental" ]; then \
+		mkdir $(CURDIR)/build/rsm/test/experimental; \
 	fi;
 
 build/%.o: %.cpp

--- a/rsm/test/experimental/exp_rsm_promotion_tests.cpp
+++ b/rsm/test/experimental/exp_rsm_promotion_tests.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "exp_recursive_shared_mutex.h"
+#include "test_cxx_rsm.h"
+#include "timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(exp_rsm_promotion_tests, TestSetup)
+
+exp_recursive_shared_mutex rsm;
+std::vector<int> rsm_guarded_vector;
+
+void helper_fail() { BOOST_CHECK_EQUAL(rsm.try_lock(), false); }
+void helper_pass()
+{
+    BOOST_CHECK_EQUAL(rsm.try_lock(), true);
+    // unlock the try_lock
+    rsm.unlock();
+}
+
+// test locking shared while holding exclusive ownership
+// we should require an equal number of unlock_shared for each lock_shared
+BOOST_AUTO_TEST_CASE(rsm_lock_shared_while_exclusive_owner)
+{
+    // lock exclusive 3 times
+    rsm.lock();
+    rsm.lock();
+    rsm.lock();
+
+    // lock_shared twice
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // it should require 3 unlocks and 2 unlock_shareds to have another thread lock exclusive
+
+    // dont unlock exclusive enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+    rsm.unlock_shared();
+
+    // we expect helper_fail to fail
+    std::thread one(helper_fail);
+    one.join();
+
+    // relock
+    rsm.lock();
+    rsm.lock();
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // now try not unlocking shared enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+
+    // again we expect helper fail to fail
+    std::thread two(helper_fail);
+    two.join();
+
+    // unlock the last shared
+    rsm.unlock_shared();
+
+    // helper pass should pass now
+    std::thread three(helper_pass);
+    three.join();
+}
+
+void shared_only()
+{
+    rsm.lock_shared();
+    // give time for theta to lock shared, eta to lock, and theta to ask for promotion
+    MilliSleep(4000);
+    rsm.unlock_shared();
+}
+
+void exclusive_only()
+{
+    rsm.lock();
+    rsm_guarded_vector.push_back(4);
+    rsm.unlock();
+}
+
+void promoting_thread()
+{
+    rsm.lock_shared();
+    // give time for eta to get in line to lock exclusive
+    MilliSleep(500);
+    bool promoted = rsm.try_promotion();
+    BOOST_CHECK_EQUAL(promoted, true);
+    rsm_guarded_vector.push_back(7);
+    rsm.unlock();
+    rsm.unlock_shared();
+}
+
+/*
+ * if a thread askes for a promotion while no other thread
+ * is currently asking for a promotion it will be put in line to grab the next
+ * exclusive lock even if another threads are waiting using lock()
+ *
+ * This test covers lock promotion from shared to exclusive.
+ *
+ */
+
+BOOST_AUTO_TEST_CASE(rsm_try_promotion)
+{
+    // clear the data vector at test start
+    rsm_guarded_vector.clear();
+    // test promotions
+    std::thread one(shared_only);
+    MilliSleep(250);
+    std::thread two(promoting_thread);
+    MilliSleep(250);
+    std::thread three(exclusive_only);
+
+    one.join();
+    two.join();
+    three.join();
+
+    // 7 was added by the promoted thread, it should appear first in the vector
+    rsm.lock_shared();
+    BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
+    BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
+    rsm.unlock_shared();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/rsm/test/experimental/exp_rsm_simple_tests.cpp
+++ b/rsm/test/experimental/exp_rsm_simple_tests.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "exp_recursive_shared_mutex.h"
+#include "test_cxx_rsm.h"
+#include "timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(exp_rsm_simple_tests, TestSetup)
+
+exp_recursive_shared_mutex rsm;
+
+// basic lock and unlock tests
+BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
+{
+    // exclusive lock once
+    rsm.lock();
+
+// try to unlock_shared an exclusive lock
+// we should error here because exclusive locks can
+// be not be unlocked by shared_ unlock method
+#ifdef DEBUG_ASSERTION
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // exclusive lock once
+    rsm.lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic lock_shared and unlock_shared tests
+BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
+{
+    // lock shared
+    rsm.lock_shared();
+
+#ifdef DEBUG_ASSERTION
+    // try to unlock exclusive when we only have shared
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    rsm.unlock_shared();
+
+#ifdef DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock tests
+BOOST_AUTO_TEST_CASE(rsm_try_lock)
+{
+    // try lock
+    rsm.try_lock();
+
+#ifdef DEBUG_ASSERTION
+    // try to unlock_shared an exclusive lock
+    // we should error here because exclusive locks can
+    // be not be unlocked by shared_ unlock method
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // try lock
+    rsm.try_lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock_shared tests
+BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
+{
+    // try lock shared
+    rsm.try_lock_shared();
+
+#ifdef DEBUG_ASSERTION
+    // unlock exclusive while we have shared lock
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+
+#ifdef DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// test locking recursively 100 times for each lock type
+BOOST_AUTO_TEST_CASE(rsm_100_lock_test)
+{
+    uint8_t i = 0;
+    // lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // try_lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // try_lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // test complete
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/rsm/test/experimental/exp_rsm_starvation_tests.cpp
+++ b/rsm/test/experimental/exp_rsm_starvation_tests.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "exp_recursive_shared_mutex.h"
+#include "test_cxx_rsm.h"
+#include "timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(exp_rsm_starvation_tests, TestSetup)
+
+class exp_rsm_watcher : public exp_recursive_shared_mutex
+{
+public:
+    size_t get_shared_owners_count() { return _read_owner_ids.size(); }
+};
+
+exp_rsm_watcher rsm;
+std::vector<int> rsm_guarded_vector;
+
+void shared_only()
+{
+    rsm.lock_shared();
+    // give time for theta to lock shared, eta to lock, and theta to ask for promotion
+    MilliSleep(2000);
+    rsm.unlock_shared();
+}
+
+void exclusive_only()
+{
+    rsm.lock();
+    rsm_guarded_vector.push_back(4);
+    rsm.unlock();
+}
+
+void promoting_thread()
+{
+    rsm.lock_shared();
+    // give time for eta to get in line to lock exclusive
+    MilliSleep(100);
+    bool promoted = rsm.try_promotion();
+    BOOST_CHECK_EQUAL(promoted, true);
+    rsm_guarded_vector.push_back(7);
+    rsm.unlock();
+    rsm.unlock_shared();
+}
+
+/*
+ * if a thread askes for a promotion while no other thread
+ * is currently asking for a promotion it will be put in line to grab the next
+ * exclusive lock even if another threads are waiting using lock()
+ *
+ * This test covers blocking of additional shared ownership aquisitions while
+ * a thread is waiting for promotion.
+ *
+ */
+
+BOOST_AUTO_TEST_CASE(rsm_test_starvation)
+{
+    // clear the data vector at test start
+    rsm_guarded_vector.clear();
+
+    // start up intial shared thread to block immidiate exclusive grabbing
+    std::thread one(shared_only);
+    std::thread two(shared_only);
+    MilliSleep(50);
+    std::thread three(promoting_thread);
+    MilliSleep(50);
+    std::thread four(exclusive_only);
+    MilliSleep(75);
+    // we should always get 3 because five, six, and seven should be blocked by
+    // three promotion request leaving only one, two, and three with shared ownership
+    BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
+    std::thread five(shared_only);
+    BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
+    std::thread six(shared_only);
+    BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
+    std::thread seven(shared_only);
+    BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
+
+    one.join();
+    two.join();
+    three.join();
+    four.join();
+    five.join();
+    six.join();
+    seven.join();
+
+    // 7 was added by the promoted thread, it should appear first in the vector
+    rsm.lock_shared();
+    BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
+    BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
+    rsm.unlock_shared();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
this allows easier testing between the exp_recursive_shared_mutex 
changes and the current version of recursive_shared_mutex