### PR TITLE
Add performance tests

### DIFF
--- a/test/experimental/exp_rsm_promotion_tests.cpp
+++ b/test/experimental/exp_rsm_promotion_tests.cpp
@@ -21,10 +21,9 @@ void helper_pass()
     // unlock the try_lock
     rsm.unlock();
 }
-
 // test locking shared while holding exclusive ownership
 // we should require an equal number of unlock_shared for each lock_shared
-BOOST_AUTO_TEST_CASE(rsm_lock_shared_while_exclusive_owner)
+void rsm_lock_shared_while_exclusive_owner()
 {
     // lock exclusive 3 times
     rsm.lock();
@@ -71,33 +70,6 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_while_exclusive_owner)
     three.join();
 }
 
-void shared_only()
-{
-    rsm.lock_shared();
-    // give time for theta to lock shared, eta to lock, and theta to ask for promotion
-    MilliSleep(4000);
-    rsm.unlock_shared();
-}
-
-void exclusive_only()
-{
-    rsm.lock();
-    rsm_guarded_vector.push_back(4);
-    rsm.unlock();
-}
-
-void promoting_thread()
-{
-    rsm.lock_shared();
-    // give time for eta to get in line to lock exclusive
-    MilliSleep(500);
-    bool promoted = rsm.try_promotion();
-    BOOST_CHECK_EQUAL(promoted, true);
-    rsm_guarded_vector.push_back(7);
-    rsm.unlock();
-    rsm.unlock_shared();
-}
-
 /*
  * if a thread askes for a promotion while no other thread
  * is currently asking for a promotion it will be put in line to grab the next
@@ -106,27 +78,83 @@ void promoting_thread()
  * This test covers lock promotion from shared to exclusive.
  *
  */
+ std::atomic<int> shared_locks{0};
+  void shared_only()
+  {
+      rsm.lock_shared();
+      shared_locks++;
+      while(shared_locks != 2) ;
 
-BOOST_AUTO_TEST_CASE(rsm_try_promotion)
+      rsm.unlock_shared();
+      shared_locks = shared_locks - 1;
+      rsm.lock();
+      rsm_guarded_vector.push_back(4);
+      rsm.unlock();
+  }
+
+  void promoting_thread()
+  {
+      while(shared_locks != 1) ;
+      rsm.lock_shared();
+      // this will increase it to 2
+      shared_locks++;
+      // wait until the other thread unlocks. they should have locked exclusive in this time
+      while(shared_locks != 1) ;
+      bool promoted = rsm.try_promotion();
+      BOOST_CHECK_EQUAL(promoted, true);
+      rsm_guarded_vector.push_back(7);
+      rsm.unlock();
+      rsm.unlock_shared();
+  }
+ void rsm_try_promotion()
+ {
+     // clear the data vector at test start
+     rsm_guarded_vector.clear();
+     shared_locks = 0;
+     // test promotions
+     std::thread one(shared_only);
+     std::thread two(promoting_thread);
+
+     one.join();
+     two.join();
+
+     // 7 was added by the promoted thread, it should appear first in the vector
+     rsm.lock_shared();
+     BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
+     BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
+     rsm.unlock_shared();
+ }
+
+ BOOST_AUTO_TEST_CASE(rsm_promotion_tests)
+ {
+     rsm_lock_shared_while_exclusive_owner();
+     rsm_try_promotion();
+ }
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
 {
-    // clear the data vector at test start
-    rsm_guarded_vector.clear();
-    // test promotions
-    std::thread one(shared_only);
-    MilliSleep(250);
-    std::thread two(promoting_thread);
-    MilliSleep(250);
-    std::thread three(exclusive_only);
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_lock_shared_while_exclusive_owner();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("EXP rsm_lock_shared_while_exclusive_owner took %" PRId64 " microseconds \n", duration_1);
 
-    one.join();
-    two.join();
-    three.join();
 
-    // 7 was added by the promoted thread, it should appear first in the vector
-    rsm.lock_shared();
-    BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
-    BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
-    rsm.unlock_shared();
+
+
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_try_promotion();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("EXP rsm_try_promotion took %" PRId64 " microseconds \n", duration_2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/experimental/exp_rsm_simple_tests.cpp
+++ b/test/experimental/exp_rsm_simple_tests.cpp
@@ -13,8 +13,7 @@ BOOST_FIXTURE_TEST_SUITE(exp_rsm_simple_tests, TestSetup)
 
 exp_recursive_shared_mutex rsm;
 
-// basic lock and unlock tests
-BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
+void rsm_lock_unlock()
 {
     // exclusive lock once
     rsm.lock();
@@ -44,8 +43,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
     // test complete
 }
 
-// basic lock_shared and unlock_shared tests
-BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
+void rsm_lock_shared_unlock_shared()
 {
     // lock shared
     rsm.lock_shared();
@@ -67,7 +65,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
 }
 
 // basic try_lock tests
-BOOST_AUTO_TEST_CASE(rsm_try_lock)
+void rsm_try_lock()
 {
     // try lock
     rsm.try_lock();
@@ -97,7 +95,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock)
 }
 
 // basic try_lock_shared tests
-BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
+ void rsm_try_lock_shared()
 {
     // try lock shared
     rsm.try_lock_shared();
@@ -119,7 +117,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
 }
 
 // test locking recursively 100 times for each lock type
-BOOST_AUTO_TEST_CASE(rsm_100_lock_test)
+void rsm_100_lock_test()
 {
     uint8_t i = 0;
     // lock
@@ -175,6 +173,65 @@ BOOST_AUTO_TEST_CASE(rsm_100_lock_test)
     }
 
     // test complete
+}
+
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests)
+{
+    rsm_lock_unlock();
+    rsm_lock_shared_unlock_shared();
+    rsm_try_lock();
+    rsm_try_lock_shared();
+    rsm_100_lock_test();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_unlock();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("EXP rsm_lock_unlock took %" PRId64 " microseconds \n", duration_1);
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_shared_unlock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("EXP rsm_lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
+
+    std::chrono::steady_clock::time_point startTime_3 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock();
+    }
+    std::chrono::steady_clock::time_point endTime_3 = GetTimeNow();
+    int64_t duration_3 = GetDuration(startTime_3, endTime_3);
+    printf("EXP rsm_try_lock took %" PRId64 " microseconds \n", duration_3);
+
+    std::chrono::steady_clock::time_point startTime_4 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_4 = GetTimeNow();
+    int64_t duration_4 = GetDuration(startTime_4, endTime_4);
+    printf("EXP rsm_try_lock_shared took %" PRId64 " microseconds \n", duration_4);
+
+    std::chrono::steady_clock::time_point startTime_5 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_100_lock_test();
+    }
+    std::chrono::steady_clock::time_point endTime_5 = GetTimeNow();
+    int64_t duration_5 = GetDuration(startTime_5, endTime_5);
+    printf("EXP rsm_100_lock_test took %" PRId64 " microseconds \n", duration_5);
 }
 
 

--- a/test/experimental/exp_rsm_starvation_tests.cpp
+++ b/test/experimental/exp_rsm_starvation_tests.cpp
@@ -20,16 +20,38 @@ public:
 exp_rsm_watcher rsm;
 std::vector<int> rsm_guarded_vector;
 
+std::atomic<int> shared_locks{0};
+std::atomic<int> exclusive_locks{0};
+std::atomic<int> rejected{0};
+
+bool shared_only_starved_last()
+{
+    return rsm.try_lock_shared();
+}
+
+void shared_only_starved()
+{
+    bool result = rsm.try_lock_shared();
+    // shoud always be false
+    if (result == false)
+    {
+        rejected++;
+    }
+    // we dont need to unlock because it never successfully locked
+}
+
 void shared_only()
 {
     rsm.lock_shared();
-    // give time for theta to lock shared, eta to lock, and theta to ask for promotion
-    MilliSleep(2000);
+    shared_locks++;
+    while (rejected != 3) ;
     rsm.unlock_shared();
 }
 
 void exclusive_only()
 {
+    while(shared_locks != 3) ;
+    exclusive_locks++;
     rsm.lock();
     rsm_guarded_vector.push_back(4);
     rsm.unlock();
@@ -38,8 +60,8 @@ void exclusive_only()
 void promoting_thread()
 {
     rsm.lock_shared();
-    // give time for eta to get in line to lock exclusive
-    MilliSleep(100);
+    shared_locks++;
+    while(exclusive_locks != 1) ;
     bool promoted = rsm.try_promotion();
     BOOST_CHECK_EQUAL(promoted, true);
     rsm_guarded_vector.push_back(7);
@@ -57,28 +79,33 @@ void promoting_thread()
  *
  */
 
-BOOST_AUTO_TEST_CASE(rsm_test_starvation)
+void rsm_test_starvation()
 {
     // clear the data vector at test start
     rsm_guarded_vector.clear();
+    shared_locks = 0;
+    exclusive_locks = 0;
+    rejected = 0;
 
     // start up intial shared thread to block immidiate exclusive grabbing
     std::thread one(shared_only);
     std::thread two(shared_only);
-    MilliSleep(50);
     std::thread three(promoting_thread);
-    MilliSleep(50);
     std::thread four(exclusive_only);
-    MilliSleep(75);
+    while (exclusive_locks != 1) ;
     // we should always get 3 because five, six, and seven should be blocked by
     // three promotion request leaving only one, two, and three with shared ownership
     BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
-    std::thread five(shared_only);
+    std::thread five(shared_only_starved);
     BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
-    std::thread six(shared_only);
+    std::thread six(shared_only_starved);
     BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
-    std::thread seven(shared_only);
+    bool result = shared_only_starved_last();
     BOOST_CHECK_EQUAL(rsm.get_shared_owners_count(), 3);
+    if (result == false)
+    {
+        rejected++;
+    }
 
     one.join();
     two.join();
@@ -86,13 +113,30 @@ BOOST_AUTO_TEST_CASE(rsm_test_starvation)
     four.join();
     five.join();
     six.join();
-    seven.join();
 
     // 7 was added by the promoted thread, it should appear first in the vector
     rsm.lock_shared();
     BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
     BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
     rsm.unlock_shared();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_starvation_test)
+{
+    rsm_test_starvation();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_test_starvation_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_test_starvation();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("rsm_test_starvation took %" PRId64 " microseconds \n", duration_1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/rsm_promotion_tests.cpp
+++ b/test/rsm_promotion_tests.cpp
@@ -21,10 +21,9 @@ void helper_pass()
     // unlock the try_lock
     rsm.unlock();
 }
-
 // test locking shared while holding exclusive ownership
 // we should require an equal number of unlock_shared for each lock_shared
-BOOST_AUTO_TEST_CASE(rsm_lock_shared_while_exclusive_owner)
+void rsm_lock_shared_while_exclusive_owner()
 {
     // lock exclusive 3 times
     rsm.lock();
@@ -71,33 +70,6 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_while_exclusive_owner)
     three.join();
 }
 
-void shared_only()
-{
-    rsm.lock_shared();
-    // give time for theta to lock shared, eta to lock, and theta to ask for promotion
-    MilliSleep(4000);
-    rsm.unlock_shared();
-}
-
-void exclusive_only()
-{
-    rsm.lock();
-    rsm_guarded_vector.push_back(4);
-    rsm.unlock();
-}
-
-void promoting_thread()
-{
-    rsm.lock_shared();
-    // give time for eta to get in line to lock exclusive
-    MilliSleep(500);
-    bool promoted = rsm.try_promotion();
-    BOOST_CHECK_EQUAL(promoted, true);
-    rsm_guarded_vector.push_back(7);
-    rsm.unlock();
-    rsm.unlock_shared();
-}
-
 /*
  * if a thread askes for a promotion while no other thread
  * is currently asking for a promotion it will be put in line to grab the next
@@ -106,27 +78,83 @@ void promoting_thread()
  * This test covers lock promotion from shared to exclusive.
  *
  */
+std::atomic<int> shared_locks{0};
+void shared_only()
+{
+    rsm.lock_shared();
+    shared_locks++;
+    while(shared_locks != 2) ;
 
-BOOST_AUTO_TEST_CASE(rsm_try_promotion)
+    rsm.unlock_shared();
+    shared_locks = shared_locks - 1;
+    rsm.lock();
+    rsm_guarded_vector.push_back(4);
+    rsm.unlock();
+}
+
+void promoting_thread()
+{
+    while(shared_locks != 1) ;
+    rsm.lock_shared();
+    // this will increase it to 2
+    shared_locks++;
+    // wait until the other thread unlocks. they should have locked exclusive in this time
+    while(shared_locks != 1) ;
+    bool promoted = rsm.try_promotion();
+    BOOST_CHECK_EQUAL(promoted, true);
+    rsm_guarded_vector.push_back(7);
+    rsm.unlock();
+    rsm.unlock_shared();
+}
+void rsm_try_promotion()
 {
     // clear the data vector at test start
     rsm_guarded_vector.clear();
+    shared_locks = 0;
     // test promotions
     std::thread one(shared_only);
-    MilliSleep(250);
     std::thread two(promoting_thread);
-    MilliSleep(250);
-    std::thread three(exclusive_only);
 
     one.join();
     two.join();
-    three.join();
 
     // 7 was added by the promoted thread, it should appear first in the vector
     rsm.lock_shared();
     BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
     BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
     rsm.unlock_shared();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests)
+{
+    rsm_lock_shared_while_exclusive_owner();
+    rsm_try_promotion();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_lock_shared_while_exclusive_owner();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("rsm_lock_shared_while_exclusive_owner took %" PRId64 " microseconds \n", duration_1);
+
+
+
+
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_try_promotion();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("rsm_try_promotion took %" PRId64 " microseconds \n", duration_2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/rsm_simple_tests.cpp
+++ b/test/rsm_simple_tests.cpp
@@ -13,8 +13,7 @@ BOOST_FIXTURE_TEST_SUITE(rsm_simple_tests, TestSetup)
 
 recursive_shared_mutex rsm;
 
-// basic lock and unlock tests
-BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
+void rsm_lock_unlock()
 {
     // exclusive lock once
     rsm.lock();
@@ -44,8 +43,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
     // test complete
 }
 
-// basic lock_shared and unlock_shared tests
-BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
+void rsm_lock_shared_unlock_shared()
 {
     // lock shared
     rsm.lock_shared();
@@ -67,7 +65,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
 }
 
 // basic try_lock tests
-BOOST_AUTO_TEST_CASE(rsm_try_lock)
+void rsm_try_lock()
 {
     // try lock
     rsm.try_lock();
@@ -97,7 +95,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock)
 }
 
 // basic try_lock_shared tests
-BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
+ void rsm_try_lock_shared()
 {
     // try lock shared
     rsm.try_lock_shared();
@@ -119,7 +117,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
 }
 
 // test locking recursively 100 times for each lock type
-BOOST_AUTO_TEST_CASE(rsm_100_lock_test)
+void rsm_100_lock_test()
 {
     uint8_t i = 0;
     // lock
@@ -175,6 +173,65 @@ BOOST_AUTO_TEST_CASE(rsm_100_lock_test)
     }
 
     // test complete
+}
+
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests)
+{
+    rsm_lock_unlock();
+    rsm_lock_shared_unlock_shared();
+    rsm_try_lock();
+    rsm_try_lock_shared();
+    rsm_100_lock_test();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_unlock();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("rsm_lock_unlock took %" PRId64 " microseconds \n", duration_1);
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_shared_unlock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("rsm_lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
+
+    std::chrono::steady_clock::time_point startTime_3 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock();
+    }
+    std::chrono::steady_clock::time_point endTime_3 = GetTimeNow();
+    int64_t duration_3 = GetDuration(startTime_3, endTime_3);
+    printf("rsm_try_lock took %" PRId64 " microseconds \n", duration_3);
+
+    std::chrono::steady_clock::time_point startTime_4 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_4 = GetTimeNow();
+    int64_t duration_4 = GetDuration(startTime_4, endTime_4);
+    printf("rsm_try_lock_shared took %" PRId64 " microseconds \n", duration_4);
+
+    std::chrono::steady_clock::time_point startTime_5 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_100_lock_test();
+    }
+    std::chrono::steady_clock::time_point endTime_5 = GetTimeNow();
+    int64_t duration_5 = GetDuration(startTime_5, endTime_5);
+    printf("rsm_100_lock_test took %" PRId64 " microseconds \n", duration_5);
 }
 
 

--- a/test/test_cxx_rsm.h
+++ b/test/test_cxx_rsm.h
@@ -6,6 +6,8 @@
 #ifndef TEST_CXX_RSM_H
 #define TEST_CXX_RSM_H
 
+#include <atomic>
+
 struct TestSetup {
     TestSetup()   { /* intentionally left blank */ }
     ~TestSetup()  { /* intentionally left blank */ }

--- a/test/timer.cpp
+++ b/test/timer.cpp
@@ -17,11 +17,6 @@ std::chrono::steady_clock::time_point GetTimeNow()
 
 int64_t GetDuration(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end)
 {
-    std::chrono::duration<int64_t, std::nano> time_span = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+    std::chrono::duration<int64_t, std::micro> time_span = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
     return time_span.count();
-}
-
-void MilliSleep(int64_t n)
-{
-    std::this_thread::sleep_for(std::chrono::milliseconds(n));
 }

--- a/test/timer.cpp
+++ b/test/timer.cpp
@@ -6,16 +6,19 @@
 #include "timer.h"
 
 #include <atomic>
+#include <ratio>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <chrono>
 #include <thread>
 
-int64_t GetTimeMillis()
+std::chrono::steady_clock::time_point GetTimeNow()
 {
-    std::chrono::milliseconds ms = std::chrono::duration_cast< std::chrono::milliseconds >(
-        std::chrono::system_clock::now().time_since_epoch());
-    return std::chrono::duration<int64_t, std::milli>(ms).count();
+    std::chrono::steady_clock::now();
+}
+
+int64_t GetDuration(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end)
+{
+    std::chrono::duration<int64_t, std::nano> time_span = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+    return time_span.count();
 }
 
 void MilliSleep(int64_t n)

--- a/test/timer.h
+++ b/test/timer.h
@@ -15,7 +15,4 @@ std::chrono::steady_clock::time_point GetTimeNow();
 
 int64_t GetDuration(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end);
 
-
-void MilliSleep(int64_t n);
-
 #endif // TIMER_H

--- a/test/timer.h
+++ b/test/timer.h
@@ -6,10 +6,16 @@
 #ifndef TIMER_H
 #define TIMER_H
 
+#include <chrono>
+#include <inttypes.h>
 #include <stdint.h>
 #include <string>
 
-int64_t GetTimeMillis();
+std::chrono::steady_clock::time_point GetTimeNow();
+
+int64_t GetDuration(std::chrono::steady_clock::time_point start, std::chrono::steady_clock::time_point end);
+
+
 void MilliSleep(int64_t n);
 
 #endif // TIMER_H


### PR DESCRIPTION
add performance tests for both the lib code and the exp code. This should provide some basis for determining if changes made the mutex faster or slower