### PR TITLE
Breakup rsm featureset

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,14 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
-include_HEADERS = include/recursive_shared_mutex.h
+include_HEADERS = \
+	include/lightweight_recursive_shared_mutex.h \
+	include/promotable_recursive_shared_mutex.h \
+	include/recursive_shared_mutex.h
 
-librsm_la_SOURCES = lib/recursive_shared_mutex.cpp \
+librsm_la_SOURCES = \
+	lib/lightweight_recursive_shared_mutex.cpp \
+	lib/promotable_recursive_shared_mutex.cpp \
+	lib/recursive_shared_mutex.cpp \
 	$(include_HEADERS)
 
 librsm_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
@@ -39,9 +45,13 @@ bin_PROGRAMS = test/test_rsm
 TEST_BINARY = test/test_rsm$(EXEEXT)
 
 test_test_rsm_SOURCES = test/test_cxx_rsm.cpp \
-	test/rsm_promotion_tests.cpp \
-	test/rsm_simple_tests.cpp \
-	test/rsm_starvation_tests.cpp \
+	test/lightweight_rsm/promotion_tests.cpp \
+	test/lightweight_rsm/simple_tests.cpp \
+	test/rsm/promotion_tests.cpp \
+	test/rsm/simple_tests.cpp \
+	test/promotable_rsm/promotion_tests.cpp \
+	test/promotable_rsm/simple_tests.cpp \
+	test/promotable_rsm/starvation_tests.cpp \
 	test/test_cxx_rsm.h \
 	test/timer.cpp \
 	test/timer.h \

--- a/include/lightweight_recursive_shared_mutex.h
+++ b/include/lightweight_recursive_shared_mutex.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef _RECURSIVE_SHARED_MUTEX_H
+#define _RECURSIVE_SHARED_MUTEX_H
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <exception>
+#include <mutex>
+#include <system_error>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+
+/**
+ * This mutex has two levels of access, shared and exclusive. Multiple threads can own this mutex in shared mode but
+ * only one can own it in exclusive mode.
+ * - A thread is considered to have ownership when it successfully calls either lock or try_lock.
+ * - A thread may recusively call lock for ownership and must call a matching number of unlock calls to end ownership.
+ * - A thread MAY call for shared ownership if it already has exclusive ownership. This should just increment the
+ * _shared_while_exclusive_counter instead of actually locking anything
+ * - A thread MAY obtain exclusive ownership if no threads excluding itself has shared ownership. (this might need to
+ * check for another write lock already queued up so we dont jump the line)
+ */
+
+
+static const std::thread::id NON_THREAD_ID = std::thread::id();
+
+class lightweight_recursive_shared_mutex
+{
+protected:
+    // Only locked when accessing counters, ids, or waiting on condition variables.
+    std::mutex _mutex;
+
+    // the read_gate is locked (blocked) when threads have write ownership
+    std::condition_variable _read_gate;
+
+    // the write_gate is locked (blocked) when threads have read ownership or someone is waiting for promotion
+    std::condition_variable _write_gate;
+
+    // holds a list of owner ids that have shared ownership and the number of times they locked it
+    std::vector<std::thread::id> _read_owner_ids;
+
+    // holds the number of shared locks the thread with exclusive ownership has
+    // this is used to allow the thread with exclusive ownership to lock_shared
+    uint64_t _shared_while_exclusive_counter;
+
+    // _write_counter tracks how many times exclusive ownership has been recursively locked
+    uint64_t _write_counter;
+    // _write_owner_id is the id of the thread with exclusive ownership
+    std::thread::id _write_owner_id;
+
+private:
+    bool end_of_exclusive_ownership();
+    bool check_for_write_lock(const std::thread::id &locking_thread_id);
+    bool check_for_write_unlock(const std::thread::id &locking_thread_id);
+
+    bool already_has_lock_shared(const std::thread::id &locking_thread_id);
+    void lock_shared_internal(const std::thread::id &locking_thread_id);
+    void unlock_shared_internal(const std::thread::id &locking_thread_id);
+
+public:
+    lightweight_recursive_shared_mutex()
+    {
+        _read_owner_ids.clear();
+        _write_counter = 0;
+        _shared_while_exclusive_counter = 0;
+        _write_owner_id = NON_THREAD_ID;
+    }
+
+    ~lightweight_recursive_shared_mutex() {}
+    lightweight_recursive_shared_mutex(const lightweight_recursive_shared_mutex &) = delete;
+    lightweight_recursive_shared_mutex &operator=(const lightweight_recursive_shared_mutex &) = delete;
+
+    /**
+     * "Wait in line" for exclusive ownership of the mutex.
+     *
+     * This call is blocking when waiting for exclusive ownership.
+     * When exclusive ownership is obtained the id of the thread that made this call
+     * is stored in _write_ownder_id and _write_counter is incremeneted by 1.
+     * When called by a thread that already has exclusive ownership,t
+     * the _write_counter is incremeneted by 1 and call does not block.
+     *
+     *
+     * @param none
+     * @return none
+     */
+    void lock();
+
+    /**
+     * Attempt to claim exclusive ownership of the mutex if no threads
+     * have exclusive or shared ownership of the mutex including this one.
+     *
+     * This call never blocks.
+     * When called by a thread that already has exclusive ownership,
+     * _write_counter is incremeneted by 1
+     *
+     *
+     * @param none
+     * @return: false on failure to obtain exclusive ownership.
+     * true when _write_counter has been incremented or exclusive ownership has been
+     * obtained
+     */
+    bool try_lock();
+
+    /**
+     * Release 1 count of exclusive ownership.
+     *
+     * This call never blocks.
+     * When called by a thread that has exclusive ownership, either _write_counter is
+     * decremented by 1. When both write_counter and _shared_while_exclusive_counter
+     * are 0, exclusive ownership is released.
+     *
+     *
+     * @param none
+     * @return: none
+     */
+    void unlock();
+
+    /**
+     * Attempt to claim shared ownership
+     *
+     * This call is blocking when waiting for shared ownership due to a thread having
+     * exclusive ownership.
+     * When shared ownership is obtained the id of the thread that made this call
+     * is stored in _read_owner_ids with a value of 1. Recursively locking for shared
+     * ownership increments the threads value in _read_owner_ids by 1.
+     * If this is called by a thread with exclusive ownership, increment the _shared_while_exclusive_counter
+     * by 1 instead of making an entry in _read_owner_ids
+     *
+     *
+     * @param none
+     * @return none
+     */
+    void lock_shared();
+
+    /**
+     * Attempt to claim shared ownership of the mutex if no threads
+     * have exclusive ownership of the mutex.
+     *
+     * This call never blocks.
+     * When called by a thread that already has shared ownership, the threads
+     * _read_owner_ids value is incremeneted by 1
+     * When called by a thread that has exclusive ownership, _shared_while_exclusive_counter is incremeneted by 1
+     *
+     *
+     * @param none
+     * @return: false on failure to obtain shared ownership.
+     * true when the threads _read_owner_ids has been incremented or shared ownership has been
+     * obtained
+     */
+    bool try_lock_shared();
+
+    /**
+     * Release 1 count of ownership
+     *
+     * This call never blocks.
+     * When called by a thread that has shared ownership, decrement the value of that thread in
+     * _read_owner_ids by 1. When that threads value reaches 0, remove it from _read_owner_ids signifying the
+     * end of shared ownership.
+     * When called by a thread with exclusive ownership decrement _shared_while_exclusive_counter by 1.
+     *
+     *
+     * @param none
+     * @return none
+     */
+    void unlock_shared();
+};
+
+
+#endif // _RECURSIVE_SHARED_MUTEX_H

--- a/lib/lightweight_recursive_shared_mutex.cpp
+++ b/lib/lightweight_recursive_shared_mutex.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "include/lightweight_recursive_shared_mutex.h"
+
+////////////////////////
+///
+/// Private Functions
+///
+
+bool lightweight_recursive_shared_mutex::end_of_exclusive_ownership()
+{
+    return (_shared_while_exclusive_counter == 0 && _write_counter == 0);
+}
+
+bool lightweight_recursive_shared_mutex::check_for_write_lock(const std::thread::id &locking_thread_id)
+{
+    return (_write_owner_id == locking_thread_id);
+}
+
+bool lightweight_recursive_shared_mutex::check_for_write_unlock(const std::thread::id &locking_thread_id)
+{
+    if (_write_owner_id != locking_thread_id)
+    {
+        return false;
+    }
+#ifdef RSM_DEBUG_ASSERTION
+    if (_shared_while_exclusive_counter == 0)
+    {
+        throw std::logic_error("can not unlock_shared more times than we locked for shared ownership while holding "
+                               "exclusive ownership");
+    }
+#endif
+    return true;
+}
+
+bool lightweight_recursive_shared_mutex::already_has_lock_shared(const std::thread::id &locking_thread_id)
+{
+    auto it = std::find(_read_owner_ids.begin(), _read_owner_ids.end(), locking_thread_id);
+    return (it != _read_owner_ids.end());
+}
+
+void lightweight_recursive_shared_mutex::lock_shared_internal(const std::thread::id &locking_thread_id)
+{
+    _read_owner_ids.emplace_back(locking_thread_id);
+}
+
+void lightweight_recursive_shared_mutex::unlock_shared_internal(const std::thread::id &locking_thread_id)
+{
+    auto it = std::find(_read_owner_ids.begin(), _read_owner_ids.end(), locking_thread_id);
+    if (it != _read_owner_ids.end())
+    {
+        _read_owner_ids.erase(it);
+    }
+#ifdef RSM_DEBUG_ASSERTION
+    else
+    {
+        throw std::logic_error("can not unlock_shared more times than we locked for shared ownership");
+    }
+#endif
+    return;
+
+}
+
+////////////////////////
+///
+/// Public Functions
+///
+
+void lightweight_recursive_shared_mutex::lock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex);
+    if (_write_owner_id == locking_thread_id)
+    {
+        _write_counter++;
+    }
+    else
+    {
+        // Wait until we can set the write-entered.
+        _read_gate.wait(_lock, [this] { return end_of_exclusive_ownership(); });
+
+        _write_counter++;
+        // Then wait until there are no more readers.
+        _write_gate.wait(
+            _lock, [this] { return _read_owner_ids.size() == 0; });
+        _write_owner_id = locking_thread_id;
+    }
+}
+
+bool lightweight_recursive_shared_mutex::try_lock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex, std::try_to_lock);
+
+    if (_write_owner_id == locking_thread_id)
+    {
+        _write_counter++;
+        return true;
+    }
+    else if (_lock.owns_lock() && end_of_exclusive_ownership() && _read_owner_ids.size() == 0)
+    {
+        _write_counter++;
+        _write_owner_id = locking_thread_id;
+        return true;
+    }
+    return false;
+}
+
+void lightweight_recursive_shared_mutex::unlock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::lock_guard<std::mutex> _lock(_mutex);
+    // you cannot unlock if you are not the write owner so check that here
+    // this might be redundant with the mutex being locked
+    if (_write_counter == 0 || _write_owner_id != locking_thread_id)
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("unlock(standard logic) incorrectly called on a thread with no exclusive lock");
+#else
+        return;
+#endif
+    }
+    _write_counter--;
+    if (end_of_exclusive_ownership())
+    {
+        // reset the write owner id back to a non thread id once we unlock all write locks
+        _write_owner_id = NON_THREAD_ID;
+        // call notify_all() while mutex is held so that another thread can't
+        // lock and unlock the mutex then destroy *this before we make the call.
+        _read_gate.notify_all();
+    }
+}
+
+void lightweight_recursive_shared_mutex::lock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex);
+    if (check_for_write_lock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter++;
+        return;
+    }
+    if (already_has_lock_shared(locking_thread_id))
+    {
+        lock_shared_internal(locking_thread_id);
+    }
+    else
+    {
+        _read_gate.wait(
+            _lock, [this] { return end_of_exclusive_ownership(); });
+        lock_shared_internal(locking_thread_id);
+    }
+}
+
+bool lightweight_recursive_shared_mutex::try_lock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex, std::try_to_lock);
+    if (check_for_write_lock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter++;
+        return true;
+    }
+    if (already_has_lock_shared(locking_thread_id))
+    {
+        lock_shared_internal(locking_thread_id);
+        return true;
+    }
+    if (!_lock.owns_lock())
+    {
+        return false;
+    }
+    if (end_of_exclusive_ownership())
+    {
+        lock_shared_internal(locking_thread_id);
+        return true;
+    }
+    return false;
+}
+
+void lightweight_recursive_shared_mutex::unlock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::lock_guard<std::mutex> _lock(_mutex);
+    if (check_for_write_unlock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter--;
+        return;
+    }
+    if (_read_owner_ids.size() == 0)
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("unlock_shared incorrectly called on a thread with no shared lock");
+#else
+        return;
+#endif
+    }
+    unlock_shared_internal(locking_thread_id);
+    if (_write_counter != 0)
+    {
+        if (_read_owner_ids.size() == 0)
+        {
+            _write_gate.notify_one();
+        }
+        else
+        {
+            _read_gate.notify_one();
+        }
+    }
+}

--- a/lib/promotable_recursive_shared_mutex.cpp
+++ b/lib/promotable_recursive_shared_mutex.cpp
@@ -1,0 +1,313 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "include/promotable_recursive_shared_mutex.h"
+
+////////////////////////
+///
+/// Private Functions
+///
+
+bool promotable_recursive_shared_mutex::end_of_exclusive_ownership()
+{
+    return (_shared_while_exclusive_counter == 0 && _write_counter == 0);
+}
+
+bool promotable_recursive_shared_mutex::check_for_write_lock(const std::thread::id &locking_thread_id)
+{
+    return (_write_owner_id == locking_thread_id);
+}
+
+bool promotable_recursive_shared_mutex::check_for_write_unlock(const std::thread::id &locking_thread_id)
+{
+    if (_write_owner_id == locking_thread_id)
+    {
+        if (_shared_while_exclusive_counter == 0)
+        {
+#ifdef RSM_DEBUG_ASSERTION
+            throw std::logic_error("can not unlock_shared more times than we locked for shared ownership while holding "
+                                   "exclusive ownership");
+#else
+            return true;
+#endif
+        }
+        return true;
+    }
+    return false;
+}
+
+bool promotable_recursive_shared_mutex::already_has_lock_shared(const std::thread::id &locking_thread_id)
+{
+    return (_read_owner_ids.find(locking_thread_id) != _read_owner_ids.end());
+}
+
+void promotable_recursive_shared_mutex::lock_shared_internal(const std::thread::id &locking_thread_id, const uint64_t &count)
+{
+    auto it = _read_owner_ids.find(locking_thread_id);
+    if (it == _read_owner_ids.end())
+    {
+        _read_owner_ids.emplace(locking_thread_id, count);
+    }
+    else
+    {
+        it->second = it->second + count;
+    }
+}
+
+void promotable_recursive_shared_mutex::unlock_shared_internal(const std::thread::id &locking_thread_id, const uint64_t &count)
+{
+    auto it = _read_owner_ids.find(locking_thread_id);
+    if (it == _read_owner_ids.end())
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("can not unlock_shared more times than we locked for shared ownership");
+#else
+        return;
+#endif
+    }
+    it->second = it->second - count;
+    if (it->second == 0)
+    {
+        _read_owner_ids.erase(it);
+    }
+}
+
+////////////////////////
+///
+/// Public Functions
+///
+
+void promotable_recursive_shared_mutex::lock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex);
+    if (_write_owner_id == locking_thread_id)
+    {
+        _write_counter++;
+    }
+    else
+    {
+        // Wait until we can set the write-entered.
+        _read_gate.wait(_lock, [this] { return end_of_exclusive_ownership(); });
+
+        _write_counter++;
+        // Then wait until there are no more readers.
+        _write_gate.wait(
+            _lock, [this] { return _read_owner_ids.size() == 0 && _promotion_candidate_id == NON_THREAD_ID; });
+        _write_owner_id = locking_thread_id;
+    }
+}
+
+bool promotable_recursive_shared_mutex::try_promotion()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex);
+
+    if (_write_owner_id == locking_thread_id)
+    {
+        _write_counter++;
+        return true;
+    }
+    // checking _write_owner_id might be redundant here with the mutex already being locked
+    // check if write_counter == 0 to ensure data consistency after promotion
+    else if (_promotion_candidate_id == NON_THREAD_ID)
+    {
+        _promotion_candidate_id = locking_thread_id;
+        // Then wait until there are no more readers.
+        _promotion_write_gate.wait(_lock,
+            [this] { return _read_owner_ids.size() == 1 && already_has_lock_shared(std::this_thread::get_id()); });
+        _write_owner_id = locking_thread_id;
+        // it is possible that if we cut the line, another thread could have incremented the _write_counter
+        // already, so we should check this and decrement + save what they did
+        if (_write_counter != 0)
+        {
+            _write_counter_reserve = _write_counter;
+            _write_counter = 0;
+        }
+        // now increment the _write_counter for our own use
+        _write_counter++;
+        return true;
+    }
+    return false;
+}
+
+bool promotable_recursive_shared_mutex::try_lock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex, std::try_to_lock);
+
+    if (_write_owner_id == locking_thread_id)
+    {
+        _write_counter++;
+        return true;
+    }
+    else if (_lock.owns_lock() && end_of_exclusive_ownership() && _read_owner_ids.size() == 0 &&
+             _promotion_candidate_id == NON_THREAD_ID)
+    {
+        _write_counter++;
+        _write_owner_id = locking_thread_id;
+        return true;
+    }
+    return false;
+}
+
+void promotable_recursive_shared_mutex::unlock()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::lock_guard<std::mutex> _lock(_mutex);
+    // you cannot unlock if you are not the write owner so check that here
+    // this might be redundant with the mutex being locked
+    if (_write_counter == 0 || _write_owner_id != locking_thread_id)
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("unlock(standard logic) incorrectly called on a thread with no exclusive lock");
+#else
+        return;
+#endif
+    }
+    if (_promotion_candidate_id != NON_THREAD_ID && _write_owner_id != _promotion_candidate_id)
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("unlock(promotion logic) incorrectly called on a thread with no exclusive lock");
+#else
+        return;
+#endif
+    }
+    if (_promotion_candidate_id != NON_THREAD_ID)
+    {
+        _write_counter--;
+        if (_write_counter == 0)
+        {
+#ifdef RSM_DEBUG_ASSERTION
+            assert(_shared_while_exclusive_counter == 0);
+#endif
+            if (_shared_while_exclusive_counter > 0)
+            {
+                lock_shared_internal(locking_thread_id, _shared_while_exclusive_counter);
+                _shared_while_exclusive_counter = 0;
+            }
+            // reset the write owner id back to a non thread id once we unlock all write locks
+            _write_owner_id = NON_THREAD_ID;
+            _promotion_candidate_id = NON_THREAD_ID;
+            // call notify_all() while mutex is held so that another thread can't
+            // lock and unlock the mutex then destroy *this before we make the call.
+
+            // it is possible that if we cut the line, another thread could have incremented the _write_counter
+            // already, restore what they did
+            if (_write_counter_reserve != 0)
+            {
+                _write_counter = _write_counter_reserve;
+                _write_counter_reserve = 0;
+            }
+
+            _read_gate.notify_all();
+        }
+    }
+    else
+    {
+        _write_counter--;
+#ifdef RSM_DEBUG_ASSERTION
+        assert(_write_counter_reserve == 0);
+#endif
+        if (end_of_exclusive_ownership())
+        {
+            // reset the write owner id back to a non thread id once we unlock all write locks
+            _write_owner_id = NON_THREAD_ID;
+            // call notify_all() while mutex is held so that another thread can't
+            // lock and unlock the mutex then destroy *this before we make the call.
+
+            _read_gate.notify_all();
+        }
+    }
+}
+
+void promotable_recursive_shared_mutex::lock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex);
+    if (check_for_write_lock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter++;
+        return;
+    }
+    if (already_has_lock_shared(locking_thread_id))
+    {
+        lock_shared_internal(locking_thread_id);
+    }
+    else
+    {
+        _read_gate.wait(
+            _lock, [this] { return end_of_exclusive_ownership() && _promotion_candidate_id == NON_THREAD_ID; });
+        lock_shared_internal(locking_thread_id);
+    }
+}
+
+bool promotable_recursive_shared_mutex::try_lock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::unique_lock<std::mutex> _lock(_mutex, std::try_to_lock);
+    if (check_for_write_lock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter++;
+        return true;
+    }
+    if (already_has_lock_shared(locking_thread_id))
+    {
+        lock_shared_internal(locking_thread_id);
+        return true;
+    }
+    if (!_lock.owns_lock())
+    {
+        return false;
+    }
+    if (end_of_exclusive_ownership() && _promotion_candidate_id == NON_THREAD_ID)
+    {
+        lock_shared_internal(locking_thread_id);
+        return true;
+    }
+    return false;
+}
+
+void promotable_recursive_shared_mutex::unlock_shared()
+{
+    const std::thread::id &locking_thread_id = std::this_thread::get_id();
+    std::lock_guard<std::mutex> _lock(_mutex);
+    if (check_for_write_unlock(locking_thread_id))
+    {
+        _shared_while_exclusive_counter--;
+        return;
+    }
+    if (_read_owner_ids.size() == 0)
+    {
+#ifdef RSM_DEBUG_ASSERTION
+        throw std::logic_error("unlock_shared incorrectly called on a thread with no shared lock");
+#else
+        return;
+#endif
+    }
+    unlock_shared_internal(locking_thread_id);
+    if (_promotion_candidate_id != NON_THREAD_ID)
+    {
+        if (_read_owner_ids.size() == 1 && already_has_lock_shared(_promotion_candidate_id))
+        {
+            _promotion_write_gate.notify_one();
+        }
+        else
+        {
+            _read_gate.notify_one();
+        }
+    }
+    else if (_write_counter != 0 && _promotion_candidate_id == NON_THREAD_ID)
+    {
+        if (_read_owner_ids.size() == 0)
+        {
+            _write_gate.notify_one();
+        }
+        else
+        {
+            _read_gate.notify_one();
+        }
+    }
+}

--- a/test/lightweight_rsm/promotion_tests.cpp
+++ b/test/lightweight_rsm/promotion_tests.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "lightweight_recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(lw_promotion_tests, TestSetup)
+
+lightweight_recursive_shared_mutex rsm;
+std::vector<int> rsm_guarded_vector;
+
+void helper_fail() { BOOST_CHECK_EQUAL(rsm.try_lock(), false); }
+void helper_pass()
+{
+    BOOST_CHECK_EQUAL(rsm.try_lock(), true);
+    // unlock the try_lock
+    rsm.unlock();
+}
+// test locking shared while holding exclusive ownership
+// we should require an equal number of unlock_shared for each lock_shared
+void rsm_lock_shared_while_exclusive_owner()
+{
+    // lock exclusive 3 times
+    rsm.lock();
+    rsm.lock();
+    rsm.lock();
+
+    // lock_shared twice
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // it should require 3 unlocks and 2 unlock_shareds to have another thread lock exclusive
+
+    // dont unlock exclusive enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+    rsm.unlock_shared();
+
+    // we expect helper_fail to fail
+    std::thread one(helper_fail);
+    one.join();
+
+    // relock
+    rsm.lock();
+    rsm.lock();
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // now try not unlocking shared enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+
+    // again we expect helper fail to fail
+    std::thread two(helper_fail);
+    two.join();
+
+    // unlock the last shared
+    rsm.unlock_shared();
+
+    // helper pass should pass now
+    std::thread three(helper_pass);
+    three.join();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests)
+{
+    rsm_lock_shared_while_exclusive_owner();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_lock_shared_while_exclusive_owner();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("LW lock_shared_while_exclusive_owner took %" PRId64 " microseconds \n", duration_1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/lightweight_rsm/simple_tests.cpp
+++ b/test/lightweight_rsm/simple_tests.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "lightweight_recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(lw_simple_tests, TestSetup)
+
+lightweight_recursive_shared_mutex rsm;
+
+void rsm_lock_unlock()
+{
+    // exclusive lock once
+    rsm.lock();
+
+// try to unlock_shared an exclusive lock
+// we should error here because exclusive locks can
+// be not be unlocked by shared_ unlock method
+#ifdef RSM_DEBUG_ASSERTION
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // exclusive lock once
+    rsm.lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+void rsm_lock_shared_unlock_shared()
+{
+    // lock shared
+    rsm.lock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive when we only have shared
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    rsm.unlock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock tests
+void rsm_try_lock()
+{
+    // try lock
+    rsm.try_lock();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock_shared an exclusive lock
+    // we should error here because exclusive locks can
+    // be not be unlocked by shared_ unlock method
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // try lock
+    rsm.try_lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock_shared tests
+ void rsm_try_lock_shared()
+{
+    // try lock shared
+    rsm.try_lock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // unlock exclusive while we have shared lock
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// test locking recursively 100 times for each lock type
+void rsm_100_lock_test()
+{
+    uint8_t i = 0;
+    // lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // try_lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // try_lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // test complete
+}
+
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests)
+{
+    rsm_lock_unlock();
+    rsm_lock_shared_unlock_shared();
+    rsm_try_lock();
+    rsm_try_lock_shared();
+    rsm_100_lock_test();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_unlock();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("LW lock_unlock took %" PRId64 " microseconds \n", duration_1);
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_shared_unlock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("LW lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
+
+    std::chrono::steady_clock::time_point startTime_3 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock();
+    }
+    std::chrono::steady_clock::time_point endTime_3 = GetTimeNow();
+    int64_t duration_3 = GetDuration(startTime_3, endTime_3);
+    printf("LW try_lock took %" PRId64 " microseconds \n", duration_3);
+
+    std::chrono::steady_clock::time_point startTime_4 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_4 = GetTimeNow();
+    int64_t duration_4 = GetDuration(startTime_4, endTime_4);
+    printf("LW try_lock_shared took %" PRId64 " microseconds \n", duration_4);
+
+    std::chrono::steady_clock::time_point startTime_5 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_100_lock_test();
+    }
+    std::chrono::steady_clock::time_point endTime_5 = GetTimeNow();
+    int64_t duration_5 = GetDuration(startTime_5, endTime_5);
+    printf("LW 100_lock_test took %" PRId64 " microseconds \n", duration_5);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/promotable_rsm/promotion_tests.cpp
+++ b/test/promotable_rsm/promotion_tests.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "promotable_recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(promotable_promotion_tests, TestSetup)
+
+promotable_recursive_shared_mutex rsm;
+std::vector<int> rsm_guarded_vector;
+
+void helper_fail() { BOOST_CHECK_EQUAL(rsm.try_lock(), false); }
+void helper_pass()
+{
+    BOOST_CHECK_EQUAL(rsm.try_lock(), true);
+    // unlock the try_lock
+    rsm.unlock();
+}
+// test locking shared while holding exclusive ownership
+// we should require an equal number of unlock_shared for each lock_shared
+void rsm_lock_shared_while_exclusive_owner()
+{
+    // lock exclusive 3 times
+    rsm.lock();
+    rsm.lock();
+    rsm.lock();
+
+    // lock_shared twice
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // it should require 3 unlocks and 2 unlock_shareds to have another thread lock exclusive
+
+    // dont unlock exclusive enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+    rsm.unlock_shared();
+
+    // we expect helper_fail to fail
+    std::thread one(helper_fail);
+    one.join();
+
+    // relock
+    rsm.lock();
+    rsm.lock();
+    rsm.lock_shared();
+    rsm.lock_shared();
+
+    // now try not unlocking shared enough times
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock();
+    rsm.unlock_shared();
+
+    // again we expect helper fail to fail
+    std::thread two(helper_fail);
+    two.join();
+
+    // unlock the last shared
+    rsm.unlock_shared();
+
+    // helper pass should pass now
+    std::thread three(helper_pass);
+    three.join();
+}
+
+/*
+ * if a thread askes for a promotion while no other thread
+ * is currently asking for a promotion it will be put in line to grab the next
+ * exclusive lock even if another threads are waiting using lock()
+ *
+ * This test covers lock promotion from shared to exclusive.
+ *
+ */
+std::atomic<int> shared_locks{0};
+void shared_only()
+{
+    rsm.lock_shared();
+    shared_locks++;
+    while(shared_locks != 2) ;
+
+    rsm.unlock_shared();
+    shared_locks = shared_locks - 1;
+    rsm.lock();
+    rsm_guarded_vector.push_back(4);
+    rsm.unlock();
+}
+
+void promoting_thread()
+{
+    while(shared_locks != 1) ;
+    rsm.lock_shared();
+    // this will increase it to 2
+    shared_locks++;
+    // wait until the other thread unlocks. they should have locked exclusive in this time
+    while(shared_locks != 1) ;
+    bool promoted = rsm.try_promotion();
+    BOOST_CHECK_EQUAL(promoted, true);
+    rsm_guarded_vector.push_back(7);
+    rsm.unlock();
+    rsm.unlock_shared();
+}
+void rsm_try_promotion()
+{
+    // clear the data vector at test start
+    rsm_guarded_vector.clear();
+    shared_locks = 0;
+    // test promotions
+    std::thread one(shared_only);
+    std::thread two(promoting_thread);
+
+    one.join();
+    two.join();
+
+    // 7 was added by the promoted thread, it should appear first in the vector
+    rsm.lock_shared();
+    BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
+    BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
+    rsm.unlock_shared();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests)
+{
+    rsm_lock_shared_while_exclusive_owner();
+    rsm_try_promotion();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_lock_shared_while_exclusive_owner();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("PRO lock_shared_while_exclusive_owner took %" PRId64 " microseconds \n", duration_1);
+
+
+
+
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_try_promotion();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("PRO try_promotion took %" PRId64 " microseconds \n", duration_2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/promotable_rsm/simple_tests.cpp
+++ b/test/promotable_rsm/simple_tests.cpp
@@ -3,15 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "recursive_shared_mutex.h"
-#include "test_cxx_rsm.h"
-#include "timer.h"
+#include "promotable_recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(rsm_simple_tests, TestSetup)
+BOOST_FIXTURE_TEST_SUITE(promotable_simple_tests, TestSetup)
 
-recursive_shared_mutex rsm;
+promotable_recursive_shared_mutex rsm;
 
 void rsm_lock_unlock()
 {
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
     }
     std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
     int64_t duration_1 = GetDuration(startTime_1, endTime_1);
-    printf("rsm_lock_unlock took %" PRId64 " microseconds \n", duration_1);
+    printf("PRO lock_unlock took %" PRId64 " microseconds \n", duration_1);
 
     std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
     for (run = 0; run < 100000; ++run)
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
     }
     std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
     int64_t duration_2 = GetDuration(startTime_2, endTime_2);
-    printf("rsm_lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
+    printf("PRO lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
 
     std::chrono::steady_clock::time_point startTime_3 = GetTimeNow();
     for (run = 0; run < 100000; ++run)
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
     }
     std::chrono::steady_clock::time_point endTime_3 = GetTimeNow();
     int64_t duration_3 = GetDuration(startTime_3, endTime_3);
-    printf("rsm_try_lock took %" PRId64 " microseconds \n", duration_3);
+    printf("PRO try_lock took %" PRId64 " microseconds \n", duration_3);
 
     std::chrono::steady_clock::time_point startTime_4 = GetTimeNow();
     for (run = 0; run < 100000; ++run)
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
     }
     std::chrono::steady_clock::time_point endTime_4 = GetTimeNow();
     int64_t duration_4 = GetDuration(startTime_4, endTime_4);
-    printf("rsm_try_lock_shared took %" PRId64 " microseconds \n", duration_4);
+    printf("PRO try_lock_shared took %" PRId64 " microseconds \n", duration_4);
 
     std::chrono::steady_clock::time_point startTime_5 = GetTimeNow();
     for (run = 0; run < 10000; ++run)
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
     }
     std::chrono::steady_clock::time_point endTime_5 = GetTimeNow();
     int64_t duration_5 = GetDuration(startTime_5, endTime_5);
-    printf("rsm_100_lock_test took %" PRId64 " microseconds \n", duration_5);
+    printf("PRO 100_lock_test took %" PRId64 " microseconds \n", duration_5);
 }
 
 

--- a/test/promotable_rsm/starvation_tests.cpp
+++ b/test/promotable_rsm/starvation_tests.cpp
@@ -3,15 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "recursive_shared_mutex.h"
-#include "test_cxx_rsm.h"
-#include "timer.h"
+#include "promotable_recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(rsm_starvation_tests, TestSetup)
+BOOST_FIXTURE_TEST_SUITE(promotable_starvation_tests, TestSetup)
 
-class rsm_watcher : public recursive_shared_mutex
+class rsm_watcher : public promotable_recursive_shared_mutex
 {
 public:
     size_t get_shared_owners_count() { return _read_owner_ids.size(); }
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(rsm_test_starvation_perf)
     }
     std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
     int64_t duration_1 = GetDuration(startTime_1, endTime_1);
-    printf("rsm_test_starvation took %" PRId64 " microseconds \n", duration_1);
+    printf("PRO test_starvation took %" PRId64 " microseconds \n", duration_1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/rsm/promotion_tests.cpp
+++ b/test/rsm/promotion_tests.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "recursive_shared_mutex.h"
-#include "test_cxx_rsm.h"
-#include "timer.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -70,65 +70,9 @@ void rsm_lock_shared_while_exclusive_owner()
     three.join();
 }
 
-/*
- * if a thread askes for a promotion while no other thread
- * is currently asking for a promotion it will be put in line to grab the next
- * exclusive lock even if another threads are waiting using lock()
- *
- * This test covers lock promotion from shared to exclusive.
- *
- */
-std::atomic<int> shared_locks{0};
-void shared_only()
-{
-    rsm.lock_shared();
-    shared_locks++;
-    while(shared_locks != 2) ;
-
-    rsm.unlock_shared();
-    shared_locks = shared_locks - 1;
-    rsm.lock();
-    rsm_guarded_vector.push_back(4);
-    rsm.unlock();
-}
-
-void promoting_thread()
-{
-    while(shared_locks != 1) ;
-    rsm.lock_shared();
-    // this will increase it to 2
-    shared_locks++;
-    // wait until the other thread unlocks. they should have locked exclusive in this time
-    while(shared_locks != 1) ;
-    bool promoted = rsm.try_promotion();
-    BOOST_CHECK_EQUAL(promoted, true);
-    rsm_guarded_vector.push_back(7);
-    rsm.unlock();
-    rsm.unlock_shared();
-}
-void rsm_try_promotion()
-{
-    // clear the data vector at test start
-    rsm_guarded_vector.clear();
-    shared_locks = 0;
-    // test promotions
-    std::thread one(shared_only);
-    std::thread two(promoting_thread);
-
-    one.join();
-    two.join();
-
-    // 7 was added by the promoted thread, it should appear first in the vector
-    rsm.lock_shared();
-    BOOST_CHECK_EQUAL(7, rsm_guarded_vector[0]);
-    BOOST_CHECK_EQUAL(4, rsm_guarded_vector[1]);
-    rsm.unlock_shared();
-}
-
 BOOST_AUTO_TEST_CASE(rsm_promotion_tests)
 {
     rsm_lock_shared_while_exclusive_owner();
-    rsm_try_promotion();
 }
 
 BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
@@ -142,19 +86,6 @@ BOOST_AUTO_TEST_CASE(rsm_promotion_tests_perf)
     std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
     int64_t duration_1 = GetDuration(startTime_1, endTime_1);
     printf("rsm_lock_shared_while_exclusive_owner took %" PRId64 " microseconds \n", duration_1);
-
-
-
-
-
-    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
-    for (run = 0; run < 10000; ++run)
-    {
-        rsm_try_promotion();
-    }
-    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
-    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
-    printf("rsm_try_promotion took %" PRId64 " microseconds \n", duration_2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/rsm/simple_tests.cpp
+++ b/test/rsm/simple_tests.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "recursive_shared_mutex.h"
+#include "test/test_cxx_rsm.h"
+#include "test/timer.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(rsm_simple_tests, TestSetup)
+
+recursive_shared_mutex rsm;
+
+void rsm_lock_unlock()
+{
+    // exclusive lock once
+    rsm.lock();
+
+// try to unlock_shared an exclusive lock
+// we should error here because exclusive locks can
+// be not be unlocked by shared_ unlock method
+#ifdef RSM_DEBUG_ASSERTION
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // exclusive lock once
+    rsm.lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+void rsm_lock_shared_unlock_shared()
+{
+    // lock shared
+    rsm.lock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive when we only have shared
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    rsm.unlock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock tests
+void rsm_try_lock()
+{
+    // try lock
+    rsm.try_lock();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock_shared an exclusive lock
+    // we should error here because exclusive locks can
+    // be not be unlocked by shared_ unlock method
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+    // try lock
+    rsm.try_lock();
+
+    // try to unlock exclusive lock
+    BOOST_CHECK_NO_THROW(rsm.unlock());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // try to unlock exclusive lock more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// basic try_lock_shared tests
+ void rsm_try_lock_shared()
+{
+    // try lock shared
+    rsm.try_lock_shared();
+
+#ifdef RSM_DEBUG_ASSERTION
+    // unlock exclusive while we have shared lock
+    BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
+#endif
+
+    // unlock shared
+    BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+
+#ifdef RSM_DEBUG_ASSERTION
+    // we should error here because we are unlocking more times than we locked
+    BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
+#endif
+
+    // test complete
+}
+
+// test locking recursively 100 times for each lock type
+void rsm_100_lock_test()
+{
+    uint8_t i = 0;
+    // lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // try_lock
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock());
+        --i;
+    }
+
+    // try_lock_shared
+    while (i < 100)
+    {
+        BOOST_CHECK_NO_THROW(rsm.try_lock_shared());
+        ++i;
+    }
+
+    while (i > 0)
+    {
+        BOOST_CHECK_NO_THROW(rsm.unlock_shared());
+        --i;
+    }
+
+    // test complete
+}
+
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests)
+{
+    rsm_lock_unlock();
+    rsm_lock_shared_unlock_shared();
+    rsm_try_lock();
+    rsm_try_lock_shared();
+    rsm_100_lock_test();
+}
+
+BOOST_AUTO_TEST_CASE(rsm_simple_tests_perf)
+{
+    uint32_t run = 0;
+    std::chrono::steady_clock::time_point startTime_1 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_unlock();
+    }
+    std::chrono::steady_clock::time_point endTime_1 = GetTimeNow();
+    int64_t duration_1 = GetDuration(startTime_1, endTime_1);
+    printf("rsm_lock_unlock took %" PRId64 " microseconds \n", duration_1);
+
+    std::chrono::steady_clock::time_point startTime_2 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_lock_shared_unlock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_2 = GetTimeNow();
+    int64_t duration_2 = GetDuration(startTime_2, endTime_2);
+    printf("rsm_lock_shared_unlock_shared took %" PRId64 " microseconds \n", duration_2);
+
+    std::chrono::steady_clock::time_point startTime_3 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock();
+    }
+    std::chrono::steady_clock::time_point endTime_3 = GetTimeNow();
+    int64_t duration_3 = GetDuration(startTime_3, endTime_3);
+    printf("rsm_try_lock took %" PRId64 " microseconds \n", duration_3);
+
+    std::chrono::steady_clock::time_point startTime_4 = GetTimeNow();
+    for (run = 0; run < 100000; ++run)
+    {
+        rsm_try_lock_shared();
+    }
+    std::chrono::steady_clock::time_point endTime_4 = GetTimeNow();
+    int64_t duration_4 = GetDuration(startTime_4, endTime_4);
+    printf("rsm_try_lock_shared took %" PRId64 " microseconds \n", duration_4);
+
+    std::chrono::steady_clock::time_point startTime_5 = GetTimeNow();
+    for (run = 0; run < 10000; ++run)
+    {
+        rsm_100_lock_test();
+    }
+    std::chrono::steady_clock::time_point endTime_5 = GetTimeNow();
+    int64_t duration_5 = GetDuration(startTime_5, endTime_5);
+    printf("rsm_100_lock_test took %" PRId64 " microseconds \n", duration_5);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This breaks up the rsm into three different versions; rsm, promotable rsm, lightweight rsm. 

The capability to promote a thread is no longer found in rsm, only in promotable rsm. This allows rsm to be a bit more performant by removing a lesser used feature. 

The lightweight rsm is a more performant rsm. It does not have the capability to promote a thread. It does less internal lock tracking and does not throw debug errors if the mutex is unlocked more times than it was locked. This version is ideal for programs that do their own lock tracking to detect deadlocks. 